### PR TITLE
Fix contact form success message and remove unused logo preload

### DIFF
--- a/about.html
+++ b/about.html
@@ -7,7 +7,6 @@
     <meta name="description" content="Meet the designer behind Gaetana Design Studios - Creating luxury interior spaces with passion and expertise">
     
     <!-- Preload critical assets -->
-    <link rel="preload" href="logo-new.png" as="image">
     <link rel="preload" href="./public/about.jpg" as="image">
     
     <!-- Google Fonts for luxury typography -->

--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
     
     <!-- Preload critical assets -->
     <link rel="preload" href="room.png" as="image">
-    <link rel="preload" href="logo-new.png" as="image">
     
     <!-- Google Fonts for luxury typography -->
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/script.js
+++ b/script.js
@@ -414,7 +414,7 @@ class FormHandler {
                 throw new Error('Network response was not ok');
             }
 
-            this.showMessage('Thank you! We'll get back to you soon.', 'success');
+            this.showMessage("Thank you! We'll get back to you soon.", 'success');
             this.form.reset();
 
         } catch (error) {


### PR DESCRIPTION
## Summary
- escape apostrophe in contact form success message to prevent syntax error
- remove unused preload references to `logo-new.png`

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b33bb1c70883269c7a9d5486d18646