### PR TITLE
Handle missing gallery grid and adjust Zapier webhook request

### DIFF
--- a/script.js
+++ b/script.js
@@ -406,8 +406,9 @@ class FormHandler {
 
             const response = await fetch('https://hooks.zapier.com/hooks/catch/22985325/uhkn3fw/', {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(payload),
+                // Use URL-encoded form data to avoid CORS preflight issues
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: new URLSearchParams(payload)
             });
 
             if (!response.ok) {
@@ -591,7 +592,10 @@ document.addEventListener('DOMContentLoaded', () => {
     new FormHandler();
     new PortfolioEffects();
     new ServiceAnimations();
-    new GalleryModal();
+    // Only initialize gallery modal when gallery elements exist
+    if (document.getElementById('galleryGrid')) {
+        new GalleryModal();
+    }
     
     // Performance and UX
     new PerformanceOptimizer();


### PR DESCRIPTION
## Summary
- Avoid console errors by only initializing the gallery modal when gallery elements exist
- Send contact form data as URL-encoded to bypass Zapier CORS restrictions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b33d3d66f08326ba6ead17b01d7eab